### PR TITLE
Remove docstring params from description

### DIFF
--- a/src/gpt_fn/utils/signature.py
+++ b/src/gpt_fn/utils/signature.py
@@ -75,6 +75,8 @@ class FunctionSignature:
     def schema(self) -> dict[str, Any]:
         vd = ValidatedFunction(self.fn, None)
         doc_string = parse(self.description())
+        descriptions = (doc_string.short_description, doc_string.long_description)
+        description = "\n\n".join(filter(None, descriptions))
 
         param_desc = {k.arg_name: k.description for k in doc_string.params}
 
@@ -100,6 +102,6 @@ class FunctionSignature:
 
         return {
             "name": self.fn.__name__,
-            "description": self.description(),
+            "description": description,
             "parameters": filter_parameter(vd.model.schema()),
         }

--- a/src/gpt_fn/utils/tests/__snapshots__/test_signature.ambr
+++ b/src/gpt_fn/utils/tests/__snapshots__/test_signature.ambr
@@ -47,6 +47,66 @@
     }),
   })
 # ---
+# name: test_function_signature[add_ext-args9-kwargs9]
+  '''
+  You are now the following python function:
+  ```
+  # add the given extension to the filename
+  
+  :param filename: the filename
+  :param ext: the extension, e.g. `.txt`
+  
+  def add_ext(filename: str, ext: str):
+  ```
+  Only respond with your `return` value.
+  - The output should be formatted as a JSON instance that conforms to the JSON schema below.
+  
+  - As an example, for the schema {"properties": {"foo": {"title": "Foo", "description": "a list of strings", "type": "array", "items": {"type": "string"}}}, "required": ["foo"]}}
+  the object {"foo": ["bar", "baz"]} is a well-formatted instance of the schema. The object {"properties": {"foo": ["bar", "baz"]}} is not well-formatted.
+  
+  - Here is the output schema:
+  ```
+  {"properties": {"ret": {"title": "Ret", "type": "string"}}, "required": ["ret"]}
+  ```
+  
+  '''
+# ---
+# name: test_function_signature[add_ext-args9-kwargs9].1
+  "add_ext('test', '.txt')"
+# ---
+# name: test_function_signature[add_ext-args9-kwargs9].2
+  dict({
+    'description': '''
+      add the given extension to the filename
+      
+      :param filename: the filename
+      :param ext: the extension, e.g. `.txt`
+  
+    ''',
+    'name': 'add_ext',
+    'parameters': dict({
+      'definitions': dict({
+      }),
+      'properties': dict({
+        'ext': dict({
+          'description': 'the extension, e.g. `.txt`',
+          'title': 'Ext',
+          'type': 'string',
+        }),
+        'filename': dict({
+          'description': 'the filename',
+          'title': 'Filename',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'filename',
+        'ext',
+      ]),
+      'type': 'object',
+    }),
+  })
+# ---
 # name: test_function_signature[complex-args5-kwargs5]
   '''
   You are now the following python function:

--- a/src/gpt_fn/utils/tests/__snapshots__/test_signature.ambr
+++ b/src/gpt_fn/utils/tests/__snapshots__/test_signature.ambr
@@ -51,7 +51,9 @@
   '''
   You are now the following python function:
   ```
-  # add the given extension to the filename
+  # Add the given extension to the filename
+  
+  This is a multiline docstring.
   
   :param filename: the filename
   :param ext: the extension, e.g. `.txt`
@@ -77,11 +79,9 @@
 # name: test_function_signature[add_ext-args9-kwargs9].2
   dict({
     'description': '''
-      add the given extension to the filename
+      Add the given extension to the filename
       
-      :param filename: the filename
-      :param ext: the extension, e.g. `.txt`
-  
+      This is a multiline docstring.
     ''',
     'name': 'add_ext',
     'parameters': dict({
@@ -193,12 +193,7 @@
 # ---
 # name: test_function_signature[concat-args2-kwargs2].2
   dict({
-    'description': '''
-      Concat two strings
-      :param a: first string
-      :param b: second string
-  
-    ''',
+    'description': 'Concat two strings',
     'name': 'concat',
     'parameters': dict({
       'definitions': dict({
@@ -251,12 +246,7 @@
 # ---
 # name: test_function_signature[concat-args3-kwargs3].2
   dict({
-    'description': '''
-      Concat two strings
-      :param a: first string
-      :param b: second string
-  
-    ''',
+    'description': 'Concat two strings',
     'name': 'concat',
     'parameters': dict({
       'definitions': dict({

--- a/src/gpt_fn/utils/tests/test_signature.py
+++ b/src/gpt_fn/utils/tests/test_signature.py
@@ -63,7 +63,9 @@ def how_many(num: Annotated[int, Field(gt=10, description="greater than 10")]) -
 
 
 def add_ext(filename: str, ext: str) -> str:
-    """add the given extension to the filename
+    """Add the given extension to the filename
+
+    This is a multiline docstring.
 
     :param filename: the filename
     :param ext: the extension, e.g. `.txt`

--- a/src/gpt_fn/utils/tests/test_signature.py
+++ b/src/gpt_fn/utils/tests/test_signature.py
@@ -63,6 +63,15 @@ def how_many(num: Annotated[int, Field(gt=10, description="greater than 10")]) -
     return num
 
 
+def add_ext(filename: str, ext: str) -> str:
+    """add the given extension to the filename
+
+    :param filename: the filename
+    :param ext: the extension, e.g. `.txt`
+    """
+    return filename + ext
+
+
 @pytest.mark.parametrize(
     "func, args, kwargs",
     [
@@ -79,6 +88,7 @@ def how_many(num: Annotated[int, Field(gt=10, description="greater than 10")]) -
         (get_current_weather, ("New York", "London"), {"unit": "celsius"}),
         (is_male, (Person(name="John", age=20),), {}),
         (how_many, (20,), {}),
+        (add_ext, ("test", ".txt"), {}),
     ],
 )
 def test_function_signature(

--- a/src/gpt_fn/utils/tests/test_signature.py
+++ b/src/gpt_fn/utils/tests/test_signature.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Any, Callable, Literal
 
 import pytest
-from pydantic import BaseModel, Field, validate_arguments
+from pydantic import BaseModel, Field
 from syrupy.assertion import SnapshotAssertion
 
 from ..signature import FunctionSignature

--- a/src/gpt_fn/utils/tests/test_signature.py
+++ b/src/gpt_fn/utils/tests/test_signature.py
@@ -57,7 +57,6 @@ def is_male(person: Person) -> bool:  # type: ignore[empty-body]
     """return the person is male"""
 
 
-@validate_arguments
 def how_many(num: Annotated[int, Field(gt=10, description="greater than 10")]) -> int:
     """return the given number"""
     return num


### PR DESCRIPTION
Ref https://github.com/livingbio/gpt-fn/issues/60

發現 https://github.com/livingbio/glab/issues/270 沒辦法正常使用 function_completion
schem 中已經有定義 parameters，description 裡面不會希望再有 params 佔 token 數