### PR TITLE
Revert "Update dependabot.yml"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,3 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "all"
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-type: "all"


### PR DESCRIPTION
Reverts livingbio/gpt-fn#188

The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
